### PR TITLE
when closed error with os.ErrClosed not io.EOF

### DIFF
--- a/filebuffer.go
+++ b/filebuffer.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"os"
 )
 
 // Buffer implements interfaces implemented by files.
@@ -57,7 +58,7 @@ func (f *Buffer) String() string {
 // either err == EOF or err == nil. The next Read should return 0, EOF.
 func (f *Buffer) Read(b []byte) (n int, err error) {
 	if f.isClosed {
-		return 0, io.EOF
+		return 0, os.ErrClosed
 	}
 	if len(b) == 0 {
 		return 0, nil
@@ -90,7 +91,7 @@ func (f *Buffer) Read(b []byte) (n int, err error) {
 // Clients of ReadAt can execute parallel ReadAt calls on the same input source.
 func (f *Buffer) ReadAt(p []byte, off int64) (n int, err error) {
 	if f.isClosed {
-		return 0, io.EOF
+		return 0, os.ErrClosed
 	}
 	if off < 0 {
 		return 0, errors.New("filebuffer.ReadAt: negative offset")
@@ -112,7 +113,7 @@ func (f *Buffer) ReadAt(p []byte, off int64) (n int, err error) {
 // by appending the passed bytes to the buffer unless the buffer is closed or index negative.
 func (f *Buffer) Write(p []byte) (n int, err error) {
 	if f.isClosed {
-		return 0, io.EOF
+		return 0, os.ErrClosed
 	}
 	if f.Index < 0 {
 		return 0, io.EOF
@@ -132,7 +133,7 @@ func (f *Buffer) Write(p []byte) (n int, err error) {
 // Seek implements io.Seeker https://golang.org/pkg/io/#Seeker
 func (f *Buffer) Seek(offset int64, whence int) (idx int64, err error) {
 	if f.isClosed {
-		return 0, io.EOF
+		return 0, os.ErrClosed
 	}
 
 	var abs int64

--- a/filebuffer_test.go
+++ b/filebuffer_test.go
@@ -136,8 +136,8 @@ func TestClose(t *testing.T) {
 		t.Fatalf("expected closing to not return an error but returned %v", err)
 	}
 	n, err := b.Write([]byte{0x42, 0x42, 0x42})
-	if err != io.EOF {
-		t.Fatalf("Expecting EOF got: %v", err)
+	if err != os.ErrClosed {
+		t.Fatalf("Expecting ErrClosed got: %v", err)
 	}
 	if n != 0 {
 		t.Fatalf("expected 0 bytes to be written but %d were reported written", n)


### PR DESCRIPTION
First, thanks so much for this library! I found it very useful for writing tests in https://github.com/tkellen/memorybox.

This PR makes `Read` on a "closed" filebuffer behave like a file, erroring with `os.ErrClosed`. I believe the current implementation tries to follow the semantics of `Read` on `bytes.Buffer`, returning `io.EOF` when "closed" (https://golang.org/src/bytes/buffer.go?s=9451:9501#L286). 

Given that `bytes.Buffer` has no notion of "closed", I believe the behavior should follow that of `os.File`, which is what, to my understanding, this library means to simulate.

For reference:
https://play.golang.org/p/e6IOpD0_F5W

Cheers!




